### PR TITLE
Persist activities using SQLite + SQLAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+SQLAlchemy

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,9 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+from .db import init_db, SessionLocal
+from .models import Activity, Participant
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -19,8 +22,8 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Sample activities used to seed DB when empty
+SAMPLE_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -39,43 +42,35 @@ activities = {
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
 }
+
+
+def seed_db_if_empty():
+    db = SessionLocal()
+    try:
+        count = db.query(Activity).count()
+        if count == 0:
+            for name, data in SAMPLE_ACTIVITIES.items():
+                act = Activity(name=name,
+                               description=data.get("description"),
+                               schedule=data.get("schedule"),
+                               max_participants=data.get("max_participants"))
+                db.add(act)
+                db.commit()
+                # add participants
+                for email in data.get("participants", []):
+                    p = Participant(email=email, activity_id=act.id)
+                    db.add(p)
+                db.commit()
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def on_startup():
+    # Initialize DB and seed sample data
+    init_db()
+    seed_db_if_empty()
 
 
 @app.get("/")
@@ -85,48 +80,60 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    db = SessionLocal()
+    try:
+        activities = {}
+        for act in db.query(Activity).all():
+            participants = [p.email for p in act.participants]
+            activities[act.name] = {
+                "description": act.description,
+                "schedule": act.schedule,
+                "max_participants": act.max_participants,
+                "participants": participants
+            }
+        return activities
+    finally:
+        db.close()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    db = SessionLocal()
+    try:
+        act = db.query(Activity).filter(Activity.name == activity_name).first()
+        if not act:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Check if already signed up
+        exists = db.query(Participant).filter(Participant.activity_id == act.id, Participant.email == email).first()
+        if exists:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        # Add participant
+        p = Participant(email=email, activity_id=act.id)
+        db.add(p)
+        db.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
+    finally:
+        db.close()
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    db = SessionLocal()
+    try:
+        act = db.query(Activity).filter(Activity.name == activity_name).first()
+        if not act:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participant = db.query(Participant).filter(Participant.activity_id == act.id, Participant.email == email).first()
+        if not participant:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        db.delete(participant)
+        db.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}
+    finally:
+        db.close()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,14 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./activities.db"
+
+# For SQLite we need this flag
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def init_db():
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    description = Column(Text)
+    schedule = Column(String)
+    max_participants = Column(Integer)
+
+    participants = relationship("Participant", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"))
+
+    activity = relationship("Activity", back_populates="participants")


### PR DESCRIPTION
This PR replaces the in-memory activities dictionary with a SQLite database using SQLAlchemy. It adds models for Activity and Participant, initializes the DB on startup, and seeds a few sample activities if the DB is empty.

Files added/changed:
- `src/db.py` - engine, session and init_db
- `src/models.py` - Activity and Participant models
- `src/app.py` - wired endpoints to use DB and seeding logic
- `requirements.txt` - added SQLAlchemy

This is a minimal migration to enable persistence. Next steps: add tests, migrations, and authentication/roles.